### PR TITLE
Added multisim to manual

### DIFF
--- a/src/compiling.rst
+++ b/src/compiling.rst
@@ -14,7 +14,14 @@ First, navigate your command line to the GOMC base directory. To compile GOMC on
   $ chmod u+x metamake.sh
   $ ./metamake.sh
 
-This script will create a bin directory and run cmake file to compile the code as well. All executable files will be generated in the “bin” directory.
+Or to use MPI mode,
+
+.. code-block:: bash
+
+  $ chmod u+x metamakeMPI.sh
+  $ ./metamakeMPI.sh
+
+This script will create a bin (or bin_MPI) directory and run cmake file to compile the code as well. All executable files will be generated in the “bin” (or "bin_MPI") directory.
 
 Windows
 -------

--- a/src/howto.rst
+++ b/src/howto.rst
@@ -515,3 +515,45 @@ Here is the example of argon (AR) adsorption at 5 bar in IRMOF-1 using NPT-GEMC 
     Pressure    5.0
 
     FixVolBox0  true
+
+
+Run a Multi-Sim
+---------------
+
+GOMC can be used to run independent simulations at different temperatures.  To do so GOMC must be compiled in MPI mode, and a couple of parameters must be added to the conf file.
+
+
+``MultiSimFolderName (MPI Compilation Required)``
+  The name of the folder to be created which contains output from the multisim.
+
+  - Value 1: String - Name of the folder to contain output
+
+  .. code-block:: text
+
+    MultiSimFolderName  outputFolderName
+
+
+
+``Temperature``
+  Sets the temperature at which the system will run.
+
+  - Value 1: Double - Constant temperature of simulation in degrees Kelvin.
+
+  - Value 1: List of Doubles - A list of constant temperatures for simulations in degrees Kelvin.
+  .. code-block:: text
+
+        #################################
+        # SIMULATION CONDITION
+        #################################
+        Temperature   270.00    280.00    290.00    300.00 
+
+.. Note:: To use more than one temperature, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one temperature is required.  To use only one temperature, use standard GOMC
+
+The rest of the conf file should be similar to how you would set up a standard GOMC simulation.
+
+To initiate the multisimulation,
+
+    .. code-block:: bash
+
+       $ mpiexec -n #ofreplicas GOMC_xxx_yyyy <optional#ofthreads> conffile 
+

--- a/src/howto.rst
+++ b/src/howto.rst
@@ -557,3 +557,4 @@ To initiate the multisimulation,
 
        $ mpiexec -n #ofreplicas GOMC_xxx_yyyy <optional#ofthreads> conffile 
 
+.. Note:: As of right now, restarting is not supported for multisims. 

--- a/src/input_file.rst
+++ b/src/input_file.rst
@@ -730,6 +730,16 @@ In this section, input file names are listed. In addition, if you want to restar
     Structure   0   ISB_T_270_k_merged.psf
     Structure   1   ISB_T_270_k_merged.psf
 
+``MultiSimFolderName (MPI Compilation Required)``
+  The name of the folder to be created which contains output from the multisim.
+
+  - Value 1: String - Name of the folder to contain output
+
+  .. code-block:: text
+
+    MultiSimFolderName  outputFolderName
+
+
 System Settings for During Run Setup
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This section contains all the variables not involved in the output of data during the simulation, or in the reading of input files at the start of the simulation. In other words, it contains settings related to the moves, the thermodynamic constants (based on choice of ensemble), and the length of the simulation.
@@ -767,6 +777,16 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
 
   - Value 1: Double - Constant temperature of simulation in degrees Kelvin.
 
+  - Value 1: List of Doubles - A list of constant temperatures for simulations in degrees Kelvin.
+  .. code-block:: text
+
+        #################################
+        # SIMULATION CONDITION
+        #################################
+        Temperature   270.00    280.00    290.00    300.00 
+
+.. Note:: To use more than one temperature, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one temperature is required.  To use only one temperature, use standard GOMC.
+  
 ``Rcut``
   Sets a specific radius that non-bonded interaction energy and force will be considered and calculated using defined potential function.
 


### PR DESCRIPTION
I added 4 entries to the manual.  
1 to the compiling.rst
![compile](https://user-images.githubusercontent.com/39970712/72388153-30172f00-36f3-11ea-8d75-f48db5085b8c.PNG)

2 to the input_file.rst
![input_newparam2](https://user-images.githubusercontent.com/39970712/72388188-41f8d200-36f3-11ea-901d-9584e8259190.PNG)
![input_newparam1](https://user-images.githubusercontent.com/39970712/72388189-41f8d200-36f3-11ea-948a-777adf743014.PNG)


1 to the end of the howTo.rst
![HowTo](https://user-images.githubusercontent.com/39970712/72388474-0e6a7780-36f4-11ea-9012-c668dfd4a3b3.PNG)


