### PR TITLE
Final manual

### DIFF
--- a/src/compiling.rst
+++ b/src/compiling.rst
@@ -14,7 +14,14 @@ First, navigate your command line to the GOMC base directory. To compile GOMC on
   $ chmod u+x metamake.sh
   $ ./metamake.sh
 
-This script will create a bin directory and run cmake file to compile the code as well. All executable files will be generated in the “bin” directory.
+Or to use MPI mode,
+
+.. code-block:: bash
+
+  $ chmod u+x metamakeMPI.sh
+  $ ./metamakeMPI.sh
+
+This script will create a bin (or bin_MPI) directory and run cmake file to compile the code as well. All executable files will be generated in the “bin” (or "bin_MPI") directory.
 
 Windows
 -------

--- a/src/howto.rst
+++ b/src/howto.rst
@@ -814,3 +814,48 @@ There are variety of tools developed to caclulate free energy difference, includ
         $ cd   alchemical-analysis
         $ sudo python setup.py install
 
+Run a Multi-Sim
+---------------
+
+GOMC can be used to run independent simulations at different temperatures.  To do so GOMC must be compiled in MPI mode, and a couple of parameters must be added to the conf file.
+
+
+``MultiSimFolderName``
+  The name of the folder to be created which contains output from the multisim.
+
+  - Value 1: String - Name of the folder to contain output
+
+  .. code-block:: text
+
+    MultiSimFolderName  outputFolderName
+
+
+
+``Temperature``
+  Sets the temperature at which the system will run.
+
+  - Value 1: Double - Constant temperature of simulation in degrees Kelvin.
+    .. code-block:: text
+
+        #################################
+        # SIMULATION CONDITION
+        #################################
+        Temperature   270.00
+
+  - Value 1: List of Doubles - A list of constant temperatures for simulations in degrees Kelvin.
+  .. code-block:: text
+
+        #################################
+        # SIMULATION CONDITION
+        #################################
+        Temperature   270.00    280.00    290.00    300.00 
+
+.. Note:: To use more than one temperature, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one temperature is required.  To use only one temperature, use standard GOMC
+
+The rest of the conf file should be similar to how you would set up a standard GOMC simulation.
+
+To initiate the multisimulation,
+
+    .. code-block:: bash
+
+       $ mpiexec -n #ofreplicas GOMC_xxx_yyyy <optional#ofthreads> conffile 

--- a/src/howto.rst
+++ b/src/howto.rst
@@ -341,6 +341,9 @@ Here is the example of restarting the NPT-GEMC simulation of dimethyl ether, fro
     OutputName          dimethylether_NPT_GEMC
 
 
+.. Note:: As of right now, restarting is not supported for Multi-Sim.
+
+
 Recalculate the energy 
 -----------------------
 
@@ -817,17 +820,20 @@ There are variety of tools developed to caclulate free energy difference, includ
 Run a Multi-Sim
 ---------------
 
-GOMC can be used to run independent simulations at different temperatures.  To do so GOMC must be compiled in MPI mode, and a couple of parameters must be added to the conf file.
-To compile in MPI mode, navigate to the GOMC/ and issue the following commands:
+GOMC can automatically generate independent simulations with varying parameters from one input file.  
+This allows the user to sample a wider seach space.  To do so GOMC must be compiled in MPI mode, 
+and a couple of parameters must be added to the conf file.
+
+To compile in MPI mode, navigate to the GOMC/ directory and issue the following commands:
 
 .. code-block:: bash
 
   $ chmod u+x metamakeMPI.sh
   $ ./metamakeMPI.sh
 
-Then once the compilation is complete, set up a simulation as you would a standard GOMC simulation.
+Then once the compilation is complete, set up the conf file as you would for a standard GOMC simulation.
 
-Finally, select one or more parameters (``Temperature``, ``Pressure``, ``ChemPot``, ``Fugacity``) and enter more than one value for such parameters separated by tab/space.
+Finally, select one or more of the following parameters (``Temperature``, ``Pressure``, ``ChemPot``, ``Fugacity``) and enter more than one value for such parameters separated by a tab or space.
 
   .. code-block:: text
 
@@ -858,19 +864,19 @@ Finally, select one or more parameters (``Temperature``, ``Pressure``, ``ChemPot
     GEMC        NPT
     Pressure    5.76    5.80    5.84    5.88 
 
-.. Note:: GOMC will allow for more than one of these parameters (i.e. ChemPot and Temperature), but the number of values given must either match between parameters or be 1.
-For example, a simulation with 5 chemPots must have either 1 temperature or 5 temperatures.  A simulation with 5 temperatures couldn't have 3 pressures.  This would cause GOMC to exit.
+.. Note:: GOMC will allow for more than one of these parameters (i.e. ChemPot and Temperature) to be greater than one, but the number of values given must either match between parameters or be one.  For example, a simulation with five chemPots must have either one temperature or five temperatures.  A simulation with five temperatures couldn't have three pressures.  This would cause GOMC to exit.
 
-
-You may elect to choose the name of the folder to which the sub-folders for each replica are contained in.
-Enter this name as ``MultiSimFolderName``.  If you don't provide this parameter, the default "MultiSimFolderName" will be used.
+A folder will be created for the output of each simulation, and the name will be generated from the parameters you choose. 
+A parent folder containing all the child folders will be created so as to not overpopulate the initial directory.  
+You may elect to choose the name of the folder in which the sub-folders for each replica are contained.
+Enter this name as a string following the ``MultiSimFolderName`` parameter.  If you don't provide this parameter, the default "MultiSimFolderName" will be used.
 
   .. code-block:: text
 
     MultiSimFolderName  outputFolderName
 
 
-.. Note:: To perform a multisim GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, a multisim must be performed  To perform a standard simulation, use standard GOMC.
+.. Note:: To perform a multisim, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, a multisim must be performed.  To perform a standard simulation, use standard GOMC.
 
 
 The rest of the conf file should be similar to how you would set up a standard GOMC simulation.

--- a/src/howto.rst
+++ b/src/howto.rst
@@ -883,7 +883,7 @@ Enter this name as a string following the ``MultiSimFolderName`` parameter.  If 
 
 The rest of the conf file should be similar to how you would set up a standard GOMC simulation.
 
-To initiate the multisimulation, first decide how many MPI processes and openMP threads you want to use and call GOMC with the following format.
+To initiate the multi-sim, first decide how many MPI processes and openMP threads you want to use and call GOMC with the following format.
 
 .. code-block:: bash
 

--- a/src/howto.rst
+++ b/src/howto.rst
@@ -847,8 +847,10 @@ Finally, select one or more of the following parameters (``Temperature``, ``Pres
     #################################
     # Mol.  Name Chem.  Pot.  (K)
     #################################
-    Fugacity   ISB     -968     -974     -978     -982
-
+    Fugacity  ISB   10.0     12.00     14.00     16.00
+    Fugacity  Si     0.0
+    Fugacity  O      0.0
+    
   .. code-block:: text
 
     #################################

--- a/src/howto.rst
+++ b/src/howto.rst
@@ -887,12 +887,12 @@ To initiate the multisimulation, first decide how many MPI processes and openMP 
 
 .. code-block:: bash
 
-    $ mpiexec -n #ofreplicas GOMC_xxx_yyyy +p<#ofthreads>(optional) conffile 
+    $ mpiexec -n #ofsimulations GOMC_xxx_yyyy +p<#ofthreads>(optional) conffile 
 
 The number of MPI processes must equal the number of simulations you wish to run.  Each will by default be assigned one openMP thread; however, if you have leftover processors, you may assign them as openMP threads.
 There must be an equal amount of openMP threads assigned to each process.
 
-A formula to determine how many threads is as follows:
+A formula to determine how many threads to use is as follows:
 
 .. math::
   OpenMP Threads = floor[(Number Of Processors Available - Number Of MPI Processes) / Number Of MPI Processes]

--- a/src/howto.rst
+++ b/src/howto.rst
@@ -818,39 +818,60 @@ Run a Multi-Sim
 ---------------
 
 GOMC can be used to run independent simulations at different temperatures.  To do so GOMC must be compiled in MPI mode, and a couple of parameters must be added to the conf file.
+To compile in MPI mode, navigate to the GOMC/ and issue the following commands:
+
+.. code-block:: bash
+
+  $ chmod u+x metamakeMPI.sh
+  $ ./metamakeMPI.sh
+
+Then once the compilation is complete, set up a simulation as you would a standard GOMC simulation.
+
+Finally, select one or more parameters (``Temperature``, ``Pressure``, ``ChemPot``, ``Fugacity``) and enter more than one value for such parameters separated by tab/space.
+
+  .. code-block:: text
+
+    #################################
+    # Mol.  Name Chem.  Pot.  (K)
+    #################################
+    ChemPot   ISB     -968     -974     -978     -982
+
+  .. code-block:: text
+
+    #################################
+    # Mol.  Name Chem.  Pot.  (K)
+    #################################
+    Fugacity   ISB     -968     -974     -978     -982
+
+  .. code-block:: text
+
+    #################################
+    # SIMULATION CONDITION
+    #################################
+    Temperature   270.00    280.00    290.00    300.00 
+
+  .. code-block:: text
+
+    #################################
+    # GEMC TYPE (DEFAULT IS NVT GEMC) 
+    #################################
+    GEMC        NPT
+    Pressure    5.76    5.80    5.84    5.88 
+
+.. Note:: GOMC will allow for more than one of these parameters (i.e. ChemPot and Temperature), but the number of values given must either match between parameters or be 1.
+For example, a simulation with 5 chemPots must have either 1 temperature or 5 temperatures.  A simulation with 5 temperatures couldn't have 3 pressures.  This would cause GOMC to exit.
 
 
-``MultiSimFolderName``
-  The name of the folder to be created which contains output from the multisim.
-
-  - Value 1: String - Name of the folder to contain output
+You may elect to choose the name of the folder to which the sub-folders for each replica are contained in.
+Enter this name as ``MultiSimFolderName``.  If you don't provide this parameter, the default "MultiSimFolderName" will be used.
 
   .. code-block:: text
 
     MultiSimFolderName  outputFolderName
 
 
+.. Note:: To perform a multisim GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, a multisim must be performed  To perform a standard simulation, use standard GOMC.
 
-``Temperature``
-  Sets the temperature at which the system will run.
-
-  - Value 1: Double - Constant temperature of simulation in degrees Kelvin.
-    .. code-block:: text
-
-        #################################
-        # SIMULATION CONDITION
-        #################################
-        Temperature   270.00
-
-  - Value 1: List of Doubles - A list of constant temperatures for simulations in degrees Kelvin.
-  .. code-block:: text
-
-        #################################
-        # SIMULATION CONDITION
-        #################################
-        Temperature   270.00    280.00    290.00    300.00 
-
-.. Note:: To use more than one temperature, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one temperature is required.  To use only one temperature, use standard GOMC
 
 The rest of the conf file should be similar to how you would set up a standard GOMC simulation.
 

--- a/src/howto.rst
+++ b/src/howto.rst
@@ -845,7 +845,7 @@ Finally, select one or more of the following parameters (``Temperature``, ``Pres
   .. code-block:: text
 
     #################################
-    # Mol.  Name Chem.  Pot.  (K)
+    # Mol.  Name Fugacity (bar)
     #################################
     Fugacity  ISB   10.0     12.00     14.00     16.00
     Fugacity  Si     0.0
@@ -866,7 +866,7 @@ Finally, select one or more of the following parameters (``Temperature``, ``Pres
     GEMC        NPT
     Pressure    5.76    5.80    5.84    5.88 
 
-.. Note:: GOMC will allow for more than one of these parameters (i.e. ChemPot and Temperature) to be greater than one, but the number of values given must either match between parameters or be one.  For example, a simulation with five chemPots must have either one temperature or five temperatures.  A simulation with five temperatures couldn't have three pressures.  This would cause GOMC to exit.
+.. Note:: GOMC will allow for more than one of these parameters (i.e. ChemPot and Temperature) to be greater than one, but the number of values given must either match between parameters or be one.  For example, a simulation with five chemPots must have either one temperature or five temperatures.  A simulation with five temperatures couldn't have three chemPots.  This would cause GOMC to exit.
 
 A folder will be created for the output of each simulation, and the name will be generated from the parameters you choose. 
 A parent folder containing all the child folders will be created so as to not overpopulate the initial directory.  

--- a/src/howto.rst
+++ b/src/howto.rst
@@ -870,7 +870,7 @@ Finally, select one or more of the following parameters (``Temperature``, ``Pres
 
 A folder will be created for the output of each simulation, and the name will be generated from the parameters you choose. 
 A parent folder containing all the child folders will be created so as to not overpopulate the initial directory.  
-You may elect to choose the name of the folder in which the sub-folders for each replica are contained.
+You may elect to choose the name of the folder in which all the sub-folders for each replica are contained.
 Enter this name as a string following the ``MultiSimFolderName`` parameter.  If you don't provide this parameter, the default "MultiSimFolderName" will be used.
 
   .. code-block:: text
@@ -883,8 +883,27 @@ Enter this name as a string following the ``MultiSimFolderName`` parameter.  If 
 
 The rest of the conf file should be similar to how you would set up a standard GOMC simulation.
 
-To initiate the multisimulation,
+To initiate the multisimulation, first decide how many MPI processes and openMP threads you want to use and call GOMC with the following format.
 
-    .. code-block:: bash
+.. code-block:: bash
 
-       $ mpiexec -n #ofreplicas GOMC_xxx_yyyy <optional#ofthreads> conffile 
+    $ mpiexec -n #ofreplicas GOMC_xxx_yyyy +p<#ofthreads>(optional) conffile 
+
+The number of MPI processes must equal the number of simulations you wish to run.  Each will by default be assigned one openMP thread; however, if you have leftover processors, you may assign them as openMP threads.
+There must be an equal amount of openMP threads assigned to each process.
+
+A formula to determine how many threads is as follows:
+
+.. math::
+  OpenMP Threads = floor[(Number Of Processors Available - Number Of MPI Processes) / Number Of MPI Processes]
+
+Floor[ ] - Rounds down a real number to the nearest integer.
+
+For example, if I have 7 processors and I wanted to run 2 simulations in my multi-sim.
+
+.. math::
+  OpenMP Threads= floor[(7 - 2) / 2] = floor[2.5] = 2
+
+.. code-block:: bash
+
+    $ mpiexec -n 2 GOMC_CPU_GEMC +p2 in.conf 

--- a/src/input_file.rst
+++ b/src/input_file.rst
@@ -862,7 +862,7 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
     GEMC        NPT
     Pressure    5.76
 
-  - List of Doubles - A list of Constant pressures in bar.
+  - Value 1: List of Doubles - A list of Constant pressures in bar.
 
   .. code-block:: text
 
@@ -1133,7 +1133,10 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
     #################################
     ChemPot   ISB     -968
 
-  - Value 1: String - The residue name to apply this chemical potential.
+
+    (MPI-GOMC Only)
+
+  - Value 1: String
   - Value 2: List of Doubles - A list of the chemical potential values in degrees Kelvin (should be negative).
 
   .. note:: 
@@ -1145,10 +1148,24 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
     #################################
     # Mol.  Name Chem.  Pot.  (K)
     #################################
-    ChemPot   ISB     -968     -974     -978     -982
+    ChemPot  ISB   10.0     12.00     14.00     16.00
+    ChemPot  Si     0.0
+    ChemPot  O      0.0
 
-.. Note:: To use more than one Chemical potential, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one Chemical potential is required.  To use only one Chemical potential, use standard GOMC.
+  Or
 
+  .. code-block:: text
+
+    #################################
+    # Mol.  Name Chem.  Pot.  (K)
+    #################################
+    ChemPot  ISB   10.0     12.00     14.00     16.00
+    ChemPot  Si     1.0       2.0       3.0       4.0
+    ChemPot  O      0.0
+
+.. Note:: To use more than one ChemPot, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one ChemPot in at least one residue is required.  To use only one value of ChemPot in all residues, use standard GOMC.
+
+.. Note:: GOMC will allow for more than one residue to have a list of values greater than length one, but the number of values for each residue given must either match the greatest length list or be equal to one. For example, a simulation with five values for ISB must have either five value for Si (and/or O) or one. Failure to follow this convention will cause GOMC to exit.
 
 ``Fugacity``
   For Grand Canonical (GC) ensemble runs only: Fugacity at which simulation is run.
@@ -1169,23 +1186,39 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
     Fugacity  Si     0.0
     Fugacity  O      0.0
 
-  - Value 1: String - The residue to apply this fugacity.
+
+    (MPI-GOMC Only)
+
+  - Value 1: String
   - Value 2: List of Doubles - A list of the fugacity values in bar.
 
   .. note:: 
     - For binary systems, include multiple copies of the tag (one per residue kind).
-    - If there is a molecule kind that cannot be transfer between boxes (in PDB file the beta value is set to 1.00 or 2.00) an arbitrary value e.g. 0.00 can be assigned to the residue name.
+    - If there is a molecule kind that cannot be transfer between boxes (in PDB file the beta value is set to 1.00 or 2.00), an arbitrary value (e.g. 0.00) can be assigned to the residue name.
 
   .. code-block:: text
 
     #################################
-    # Mol.  Name Fugacity (bar)
+    # Mol.  Name Chem.  Pot.  (K)
     #################################
     Fugacity  ISB   10.0     12.00     14.00     16.00
     Fugacity  Si     0.0
     Fugacity  O      0.0
 
-.. Note:: To use more than one Fugacity, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one Fugacity is required.  To use only one Fugacity, use standard GOMC.
+  Or
+
+  .. code-block:: text
+
+    #################################
+    # Mol.  Name Chem.  Pot.  (K)
+    #################################
+    Fugacity  ISB   10.0     12.00     14.00     16.00
+    Fugacity  Si     1.0       2.0       3.0       4.0
+    Fugacity  O      0.0
+
+.. Note:: To use more than one fugacity, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one fugacity in at least one residue is required.  To use only one value of fugacity in all residues, use standard GOMC.
+
+.. Note:: GOMC will allow for more than one residue to have a list of values greater than length one, but the number of values for each residue given must either match the greatest length list or be equal to one. For example, a simulation with five values for ISB must have either five values for Si (and/or O) or one. Failure to follow this convention will cause GOMC to exit.
 
 ``DisFreq``
   Fractional percentage at which displacement move will occur.

--- a/src/input_file.rst
+++ b/src/input_file.rst
@@ -820,6 +820,16 @@ In this section, input file names are listed. In addition, if you want to restar
     Structure   0   ISB_T_270_k_merged.psf
     Structure   1   ISB_T_270_k_merged.psf
 
+``MultiSimFolderName (MPI Compilation Required)``
+  The name of the folder to be created which contains output from the multisim.
+
+  - Value 1: String - Name of the folder to contain output
+
+  .. code-block:: text
+
+    MultiSimFolderName  outputFolderName
+
+
 System Settings for During Run Setup
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This section contains all the variables not involved in the output of data during the simulation, or in the reading of input files at the start of the simulation. In other words, it contains settings related to the moves, the thermodynamic constants (based on choice of ensemble), and the length of the simulation.
@@ -852,11 +862,33 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
     GEMC        NPT
     Pressure    5.76
 
+  - List of Doubles - A list of Constant pressures in bar.
+
+  .. code-block:: text
+
+    #################################
+    # GEMC TYPE (DEFAULT IS NVT GEMC) 
+    #################################
+    GEMC        NPT
+    Pressure    5.76    5.80    5.84    5.88 
+
+.. Note:: To use more than one pressure, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one pressure is required.  To use only one pressure, use standard GOMC.
+
 ``Temperature``
   Sets the temperature at which the system will run.
 
   - Value 1: Double - Constant temperature of simulation in degrees Kelvin.
 
+  - Value 1: List of Doubles - A list of constant temperatures for simulations in degrees Kelvin.
+  .. code-block:: text
+
+        #################################
+        # SIMULATION CONDITION
+        #################################
+        Temperature   270.00    280.00    290.00    300.00 
+
+.. Note:: To use more than one temperature, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one temperature is required.  To use only one temperature, use standard GOMC.
+  
 ``Rcut``
   Sets a specific radius that non-bonded interaction energy and force will be considered and calculated using defined potential function.
 
@@ -1093,6 +1125,23 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
     #################################
     ChemPot   ISB     -968
 
+  - Value 1: String - The residue name to apply this chemical potential.
+  - Value 2: List of Doubles - A list of the chemical potential values in degrees Kelvin (should be negative).
+
+  .. note:: 
+    - For binary systems, include multiple copies of the tag (one per residue kind).
+    - If there is a molecule kind that cannot be transfer between boxes (in PDB file the beta value is set to 1.00 or 2.00), an arbitrary value (e.g. 0.00) can be assigned to the residue name.
+
+  .. code-block:: text
+
+    #################################
+    # Mol.  Name Chem.  Pot.  (K)
+    #################################
+    ChemPot   ISB     -968     -974     -978     -982
+
+.. Note:: To use more than one Chemical potential, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one Chemical potential is required.  To use only one Chemical potential, use standard GOMC.
+
+
 ``Fugacity``
   For Grand Canonical (GC) ensemble runs only: Fugacity at which simulation is run.
   
@@ -1111,6 +1160,24 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
     Fugacity  ISB   10.0
     Fugacity  Si     0.0
     Fugacity  O      0.0
+
+  - Value 1: String - The residue to apply this fugacity.
+  - Value 2: List of Doubles - A list of the fugacity values in bar.
+
+  .. note:: 
+    - For binary systems, include multiple copies of the tag (one per residue kind).
+    - If there is a molecule kind that cannot be transfer between boxes (in PDB file the beta value is set to 1.00 or 2.00) an arbitrary value e.g. 0.00 can be assigned to the residue name.
+
+  .. code-block:: text
+
+    #################################
+    # Mol.  Name Fugacity (bar)
+    #################################
+    Fugacity  ISB   10.0     12.00     14.00     16.00
+    Fugacity  Si     0.0     1.0         2.0       3.0
+    Fugacity  O      0.0     0.5        0.75       1.0
+
+.. Note:: To use more than one Fugacity, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one Fugacity is required.  To use only one Fugacity, use standard GOMC.
 
 ``DisFreq``
   Fractional percentage at which displacement move will occur.

--- a/src/input_file.rst
+++ b/src/input_file.rst
@@ -880,7 +880,8 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
   - Value 1: Double - Constant temperature of simulation in degrees Kelvin.
 
   - Value 1: List of Doubles - A list of constant temperatures for simulations in degrees Kelvin.
-  .. code-block:: text
+  
+.. code-block:: text
 
         #################################
         # SIMULATION CONDITION
@@ -1174,8 +1175,8 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
     # Mol.  Name Fugacity (bar)
     #################################
     Fugacity  ISB   10.0     12.00     14.00     16.00
-    Fugacity  Si     0.0     1.0         2.0       3.0
-    Fugacity  O      0.0     0.5        0.75       1.0
+    Fugacity  Si     0.0       1.0       2.0       3.0
+    Fugacity  O      0.0       0.5      0.75       1.0
 
 .. Note:: To use more than one Fugacity, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one Fugacity is required.  To use only one Fugacity, use standard GOMC.
 

--- a/src/input_file.rst
+++ b/src/input_file.rst
@@ -1122,10 +1122,6 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
   - Value 1: String - The residue name to apply this chemical potential.
   - Value 2: Double - The chemical potential value in degrees Kelvin (should be negative).
 
-  .. note:: 
-    - For binary systems, include multiple copies of the tag (one per residue kind).
-    - If there is a molecule kind that cannot be transfer between boxes (in PDB file the beta value is set to 1.00 or 2.00), an arbitrary value (e.g. 0.00) can be assigned to the residue name.
-
   .. code-block:: text
 
     #################################

--- a/src/input_file.rst
+++ b/src/input_file.rst
@@ -1182,8 +1182,8 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
     # Mol.  Name Fugacity (bar)
     #################################
     Fugacity  ISB   10.0     12.00     14.00     16.00
-    Fugacity  Si     0.0       1.0       2.0       3.0
-    Fugacity  O      0.0       0.5      0.75       1.0
+    Fugacity  Si     0.0
+    Fugacity  O      0.0
 
 .. Note:: To use more than one Fugacity, GOMC must be compiled in MPI mode.  Also, if GOMC is compiled in MPI mode, more than one Fugacity is required.  To use only one Fugacity, use standard GOMC.
 

--- a/src/input_file.rst
+++ b/src/input_file.rst
@@ -820,7 +820,7 @@ In this section, input file names are listed. In addition, if you want to restar
     Structure   0   ISB_T_270_k_merged.psf
     Structure   1   ISB_T_270_k_merged.psf
 
-``MultiSimFolderName (MPI Compilation Required)``
+``MultiSimFolderName``
   The name of the folder to be created which contains output from the multisim.
 
   - Value 1: String - Name of the folder to contain output
@@ -879,9 +879,16 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
 
   - Value 1: Double - Constant temperature of simulation in degrees Kelvin.
 
+  .. code-block:: text
+
+        #################################
+        # SIMULATION CONDITION
+        #################################
+        Temperature   270.00 
+
   - Value 1: List of Doubles - A list of constant temperatures for simulations in degrees Kelvin.
   
-.. code-block:: text
+  .. code-block:: text
 
         #################################
         # SIMULATION CONDITION

--- a/src/input_file.rst
+++ b/src/input_file.rst
@@ -1132,12 +1132,12 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
 
     (MPI-GOMC Only)
 
-  - Value 1: String
+  - Value 1: String - The residue name to apply this chemical potential.
   - Value 2: List of Doubles - A list of the chemical potential values in degrees Kelvin (should be negative).
 
   .. note:: 
     - For binary systems, include multiple copies of the tag (one per residue kind).
-    - If there is a molecule kind that cannot be transfer between boxes (in PDB file the beta value is set to 1.00 or 2.00), an arbitrary value (e.g. 0.00) can be assigned to the residue name.
+    - If there is a molecule kind that cannot be transfer between boxes (in PDB file the beta value is set to 1.00 or 2.00), an arbitrary value (e.g. 0.00) can be assigned to the residue value.
 
   .. code-block:: text
 
@@ -1169,10 +1169,6 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
   - Value 1: String - The residue to apply this fugacity.
   - Value 2: Double - The fugacity value in bar.
 
-  .. note:: 
-    - For binary systems, include multiple copies of the tag (one per residue kind).
-    - If there is a molecule kind that cannot be transfer between boxes (in PDB file the beta value is set to 1.00 or 2.00) an arbitrary value e.g. 0.00 can be assigned to the residue name.
-
   .. code-block:: text
 
     #################################
@@ -1185,17 +1181,17 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
 
     (MPI-GOMC Only)
 
-  - Value 1: String
+  - Value 1: String - The residue to apply this fugacity.
   - Value 2: List of Doubles - A list of the fugacity values in bar.
 
   .. note:: 
     - For binary systems, include multiple copies of the tag (one per residue kind).
-    - If there is a molecule kind that cannot be transfer between boxes (in PDB file the beta value is set to 1.00 or 2.00), an arbitrary value (e.g. 0.00) can be assigned to the residue name.
+    - If there is a molecule kind that cannot be transfer between boxes (in PDB file the beta value is set to 1.00 or 2.00), an arbitrary value (e.g. 0.00) can be assigned to the residue value.
 
   .. code-block:: text
 
     #################################
-    # Mol.  Name Chem.  Pot.  (K)
+    # Mol.  Name Fugacity (bar)
     #################################
     Fugacity  ISB   10.0     12.00     14.00     16.00
     Fugacity  Si     0.0
@@ -1206,7 +1202,7 @@ Note that some tags, or entries for tags, are only used in certain ensembles (e.
   .. code-block:: text
 
     #################################
-    # Mol.  Name Chem.  Pot.  (K)
+    # Mol.  Name Fugacity (bar)
     #################################
     Fugacity  ISB   10.0     12.00     14.00     16.00
     Fugacity  Si     1.0       2.0       3.0       4.0

--- a/src/software_requirements.rst
+++ b/src/software_requirements.rst
@@ -56,7 +56,7 @@ The minimum required version is 2.8. However, we recommend to use version 3.2 or
 
 CUDA Toolkit
 ------------
-CUDA is required to compile the GPU executable in both Windows and Linux. However, is not required to compile the CPU code. To download and install CUDA visit NVIDIA’s webpage:
+CUDA is required to compile the GPU executable in both Windows and Linux. However, it is not required to compile the CPU code. To download and install CUDA visit NVIDIA’s webpage:
 
 https://developer.nvidia.com/cuda-downloads
 
@@ -77,3 +77,23 @@ To check the version number:
   $ nvcc --version
 
 The GPU builds of the code requires NVIDIA’s CUDA 8.0 or newer.
+
+MPI (Optional for Standard; Required for MultiSim)
+--------------------------------------------------
+An MPI Library is required to compile the MPI version of GOMC in both Windows and Linux.  However, it is not required to compile standard GOMC.  There are a couple of options to install an MPI library.  
+
+1) We recommend the Intel MPI Library:
+
+  https://software.intel.com/en-us/mpi-library
+
+2) The alternative we recommend to Intel MPI is MPICH. MPICH binary packages are available in many UNIX distributions and for Windows. For example, you can search for it using “yum” (on Fedora), “apt” (Debian/Ubuntu), “pkg_add” (FreeBSD) or “port”/”brew” (Mac OS).
+  
+  .. code-block:: bash
+
+  $ sudo apt-get install mpich
+
+3) Another option is the OpenMPI library.
+  
+  .. code-block:: bash
+
+  $ sudo apt-get install openmpi-bin openmpi-common openssh-client openssh-server libopenmpi2 libopenmpi-dev


### PR DESCRIPTION
Added an example for Multisim with explanation and a formula to calculate how many openMP threads to use based on processors available and number of simulations running. Also added an MPI section to required software with 3 sources of MPI libraries and how to install.  Added compilation instructions in compile file.  Also added extensive instructions on how to use more than one pres, chemPot, temperature, and fugacity, how they can be mixed and matched, and the conditions that will cause GOMC to exit in the input_file.rst.